### PR TITLE
Build off of CODE-RADE build container

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Build Status](https://travis-ci.org/AAROC/CODE-RADE-testbench.svg?branch=master)](https://travis-ci.org/AAROC/CODE-RADE-testbench) [![Docker Repository on Quay](https://quay.io/repository/aaroc/code-rade-testbench/status "Docker Repository on Quay")](https://quay.io/repository/aaroc/code-rade-testbench) 
 <!-- A brief description of the role goes here. -->
 This is a container-enabled role to create the testbench image used in running unit tests of CODE-RADE repo code.
+It is based off of the standard [CODE-RADE build container](https://github.com/AAROC/CODE-RADE-container) with some extra language-specific tools described below.
 This image is used during the first part of the testing pipeline, to run unit and linting tests on the code in the repo under question.
 It contains the following runtime environments:
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -32,6 +32,7 @@ pips:
   - pytest
   - mock
   - requests
+  - flake8
 ruby_packages:
   - ruby
   - ruby-devel

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -7,7 +7,7 @@ lint:
   name: yamllint
 platforms:
   - name: instance
-    image: centos:7
+    image: quay.io/aaroc/code-rade-centos7:latest
 provisioner:
   name: ansible
   lint:

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -23,9 +23,22 @@ def test_python_installed(host, p):
     assert pkg.is_installed
 
 
-# @pytest.mark.parametrize("pip_package", ["pytest"])
-# def test_python_tools(host):
-#     assert host.pip_package.get_packages()
+@pytest.mark.parametrize("pip", ["pytest",
+                                 "flake8"])
+def test_python2_tools(host, pip):
+    # set up python2
+    pip2_packages = host.pip_package\
+                        .get_packages(pip_path='/home/jenkins/python2/bin/pip')
+    assert pip in pip2_packages
+
+
+@pytest.mark.parametrize("pip", ["pytest",
+                                 "flake8"])
+def test_python3_tools(host, pip):
+    # set up python2
+    pip3_packages = host.pip_package\
+                        .get_packages(pip_path='/home/jenkins/python3/bin/pip')
+    assert pip in pip3_packages
 
 
 @pytest.mark.parametrize("p", ["ruby",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+molecule
+pymarkdownlint
+docker-py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,0 @@
-molecule
-pymarkdownlint
-docker-py

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,17 +10,6 @@
     name: "{{ item }}"
     state: "present"
   loop: "{{ prerequisites }}"
-- name: Add jenkins user
-  user:
-    name: jenkins
-    comment: "testing user"
-    home: /home/jenkins
-    uid: 1000
-    ssh_key_comment: ansible-generated
-    shell: /bin/bash
-    local: true
-    state: present
-
 - include_tasks: "python_testing.yml"
 - include_tasks: "ruby_testing.yml"
 - include_tasks: "security.yml"


### PR DESCRIPTION
**Related issue**: none

# Short summary of changes

Changed the base image to CODE-RADE  build container so that Jenkins can get into the image once it's provisioned. Added a few tests for the python tools.