### PR TITLE
Remove kerrnel-debug-devel from the image

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,6 +20,9 @@ prerequisites:
   - curl
   - sqlite-devel
   - ShellCheck
+remove_packages:
+  - kernel-debug-devel
+  - kernel-headers
 python_packages:
   - python2
   - python36

--- a/tasks/security.yml
+++ b/tasks/security.yml
@@ -2,5 +2,6 @@
 # security updates tasks
 - name: "Ensure kernel headers up to date"
   package:
-    name: 'kernel-headers'
+    name: "{{ item }}"
     state: absent
+  loop: "{{ remove_packages }}"


### PR DESCRIPTION
**Related issue**: None

# Short summary of changes
The kernel-debug package was included in the CODE-RADE-container - it has exposed security bugs - https://quay.io/repository/aaroc/code-rade-testbed/manifest/sha256:49f352fd2db53b16d897942a3d05a9ce23268edb14e59eb8710ed1a9a4d40cfd?tab=vulnerabilities